### PR TITLE
Sketch out a two-model BigInt

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -90,6 +90,7 @@ models:
   BigInt:
     model:
       - github.com/DIMO-Network/identity-api/graph/types.Int
+      - github.com/DIMO-Network/identity-api/graph/types.BigInt
   Bytes:
     model: github.com/DIMO-Network/identity-api/graph/types.Bytes
   DCN:

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -8,6 +8,7 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"math/big"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -104,6 +105,10 @@ type ComplexityRoot struct {
 		TokenID  func(childComplexity int) int
 	}
 
+	NodeRewards struct {
+		Total func(childComplexity int) int
+	}
+
 	PageInfo struct {
 		EndCursor       func(childComplexity int) int
 		HasNextPage     func(childComplexity int) int
@@ -156,6 +161,7 @@ type ComplexityRoot struct {
 		Name              func(childComplexity int) int
 		Owner             func(childComplexity int) int
 		Privileges        func(childComplexity int, first *int, after *string, last *int, before *string, filterBy model.PrivilegeFilterBy) int
+		Rewards           func(childComplexity int) int
 		SyntheticDevice   func(childComplexity int) int
 		TokenID           func(childComplexity int) int
 	}
@@ -449,6 +455,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Manufacturer.TokenID(childComplexity), true
 
+	case "NodeRewards.total":
+		if e.complexity.NodeRewards.Total == nil {
+			break
+		}
+
+		return e.complexity.NodeRewards.Total(childComplexity), true
+
 	case "PageInfo.endCursor":
 		if e.complexity.PageInfo.EndCursor == nil {
 			break
@@ -714,6 +727,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Vehicle.Privileges(childComplexity, args["first"].(*int), args["after"].(*string), args["last"].(*int), args["before"].(*string), args["filterBy"].(model.PrivilegeFilterBy)), true
+
+	case "Vehicle.rewards":
+		if e.complexity.Vehicle.Rewards == nil {
+			break
+		}
+
+		return e.complexity.Vehicle.Rewards(childComplexity), true
 
 	case "Vehicle.syntheticDevice":
 		if e.complexity.Vehicle.SyntheticDevice == nil {
@@ -1605,6 +1625,8 @@ func (ec *executionContext) fieldContext_AftermarketDevice_vehicle(ctx context.C
 				return ec.fieldContext_Vehicle_dcn(ctx, field)
 			case "name":
 				return ec.fieldContext_Vehicle_name(ctx, field)
+			case "rewards":
+				return ec.fieldContext_Vehicle_rewards(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Vehicle", field.Name)
 		},
@@ -2304,6 +2326,8 @@ func (ec *executionContext) fieldContext_DCN_vehicle(ctx context.Context, field 
 				return ec.fieldContext_Vehicle_dcn(ctx, field)
 			case "name":
 				return ec.fieldContext_Vehicle_name(ctx, field)
+			case "rewards":
+				return ec.fieldContext_Vehicle_rewards(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Vehicle", field.Name)
 		},
@@ -2690,6 +2714,50 @@ func (ec *executionContext) fieldContext_Manufacturer_mintedAt(ctx context.Conte
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NodeRewards_total(ctx context.Context, field graphql.CollectedField, obj *model.NodeRewards) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NodeRewards_total(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Total, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*big.Int)
+	fc.Result = res
+	return ec.marshalNBigInt2ᚖmathᚋbigᚐInt(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NodeRewards_total(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NodeRewards",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type BigInt does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3454,6 +3522,8 @@ func (ec *executionContext) fieldContext_Query_vehicle(ctx context.Context, fiel
 				return ec.fieldContext_Vehicle_dcn(ctx, field)
 			case "name":
 				return ec.fieldContext_Vehicle_name(ctx, field)
+			case "rewards":
+				return ec.fieldContext_Vehicle_rewards(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Vehicle", field.Name)
 		},
@@ -4619,6 +4689,54 @@ func (ec *executionContext) fieldContext_Vehicle_name(ctx context.Context, field
 	return fc, nil
 }
 
+func (ec *executionContext) _Vehicle_rewards(ctx context.Context, field graphql.CollectedField, obj *model.Vehicle) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Vehicle_rewards(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Rewards, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.NodeRewards)
+	fc.Result = res
+	return ec.marshalNNodeRewards2ᚖgithubᚗcomᚋDIMOᚑNetworkᚋidentityᚑapiᚋgraphᚋmodelᚐNodeRewards(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Vehicle_rewards(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Vehicle",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "total":
+				return ec.fieldContext_NodeRewards_total(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type NodeRewards", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _VehicleConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *model.VehicleConnection) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_VehicleConnection_totalCount(ctx, field)
 	if err != nil {
@@ -4774,6 +4892,8 @@ func (ec *executionContext) fieldContext_VehicleConnection_nodes(ctx context.Con
 				return ec.fieldContext_Vehicle_dcn(ctx, field)
 			case "name":
 				return ec.fieldContext_Vehicle_name(ctx, field)
+			case "rewards":
+				return ec.fieldContext_Vehicle_rewards(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Vehicle", field.Name)
 		},
@@ -4896,6 +5016,8 @@ func (ec *executionContext) fieldContext_VehicleEdge_node(ctx context.Context, f
 				return ec.fieldContext_Vehicle_dcn(ctx, field)
 			case "name":
 				return ec.fieldContext_Vehicle_name(ctx, field)
+			case "rewards":
+				return ec.fieldContext_Vehicle_rewards(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Vehicle", field.Name)
 		},
@@ -7433,6 +7555,45 @@ func (ec *executionContext) _Manufacturer(ctx context.Context, sel ast.Selection
 	return out
 }
 
+var nodeRewardsImplementors = []string{"NodeRewards"}
+
+func (ec *executionContext) _NodeRewards(ctx context.Context, sel ast.SelectionSet, obj *model.NodeRewards) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, nodeRewardsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("NodeRewards")
+		case "total":
+			out.Values[i] = ec._NodeRewards_total(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var pageInfoImplementors = []string{"PageInfo"}
 
 func (ec *executionContext) _PageInfo(ctx context.Context, sel ast.SelectionSet, obj *model.PageInfo) graphql.Marshaler {
@@ -8072,6 +8233,11 @@ func (ec *executionContext) _Vehicle(ctx context.Context, sel ast.SelectionSet, 
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "rewards":
+			out.Values[i] = ec._Vehicle_rewards(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -8680,6 +8846,27 @@ func (ec *executionContext) marshalNBigInt2int(ctx context.Context, sel ast.Sele
 	return res
 }
 
+func (ec *executionContext) unmarshalNBigInt2ᚖmathᚋbigᚐInt(ctx context.Context, v interface{}) (*big.Int, error) {
+	res, err := types.UnmarshalBigInt(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNBigInt2ᚖmathᚋbigᚐInt(ctx context.Context, sel ast.SelectionSet, v *big.Int) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	res := types.MarshalBigInt(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interface{}) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -8763,6 +8950,16 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNNodeRewards2ᚖgithubᚗcomᚋDIMOᚑNetworkᚋidentityᚑapiᚋgraphᚋmodelᚐNodeRewards(ctx context.Context, sel ast.SelectionSet, v *model.NodeRewards) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._NodeRewards(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNPageInfo2ᚖgithubᚗcomᚋDIMOᚑNetworkᚋidentityᚑapiᚋgraphᚋmodelᚐPageInfo(ctx context.Context, sel ast.SelectionSet, v *model.PageInfo) graphql.Marshaler {

--- a/graph/model/models_custom.go
+++ b/graph/model/models_custom.go
@@ -1,0 +1,8 @@
+package model
+
+import "math/big"
+
+// Custom model so that we can use a non-standard Go type for the GraphQL type BigInt.
+type NodeRewards struct {
+	Total *big.Int `json:"total"`
+}

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -174,10 +174,11 @@ type Vehicle struct {
 	SyntheticDevice *SyntheticDevice `json:"syntheticDevice,omitempty"`
 	// The device definition for this vehicle; which includes make, model, and year among
 	// other things.
-	Definition     *Definition `json:"definition,omitempty"`
-	Dcn            *Dcn        `json:"dcn,omitempty"`
-	Name           string      `json:"name"`
-	ManufacturerID *int        `json:"-"`
+	Definition     *Definition  `json:"definition,omitempty"`
+	Dcn            *Dcn         `json:"dcn,omitempty"`
+	Name           string       `json:"name"`
+	Rewards        *NodeRewards `json:"rewards"`
+	ManufacturerID *int         `json:"-"`
 }
 
 func (Vehicle) IsNode()            {}

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -181,6 +181,12 @@ type Vehicle implements Node {
   definition: Definition
   dcn: DCN
   name: String!
+
+  rewards: NodeRewards!
+}
+
+type NodeRewards {
+  total: BigInt!
 }
 
 type Definition {

--- a/graph/types/blockchain.go
+++ b/graph/types/blockchain.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"strconv"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -61,3 +62,23 @@ func MarshalInt(x int) graphql.Marshaler {
 
 // Is this going to work?
 var UnmarshalInt = graphql.UnmarshalInt
+
+func MarshalBigInt(x *big.Int) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		_, _ = io.WriteString(w, strconv.Quote(x.String()))
+	})
+}
+
+func UnmarshalBigInt(v interface{}) (*big.Int, error) {
+	s, ok := v.(string)
+	if !ok {
+		return nil, fmt.Errorf("type %T not a string", v)
+	}
+
+	out, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return nil, errors.New("couldn't parse big integer")
+	}
+
+	return out, nil
+}

--- a/internal/repositories/vehicles.go
+++ b/internal/repositories/vehicles.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"math/big"
 	"strings"
 	"time"
 
@@ -60,6 +61,9 @@ func VehicleToAPI(v *models.Vehicle) *gmodel.Vehicle {
 		},
 		ManufacturerID: v.ManufacturerID.Ptr(),
 		Name:           name,
+		Rewards: &gmodel.NodeRewards{
+			Total: new(big.Int).Mul(big.NewInt(1337), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)),
+		},
 	}
 }
 


### PR DESCRIPTION
<img width="1007" alt="image" src="https://github.com/DIMO-Network/identity-api/assets/79415431/9012ac61-13d5-44c6-b42c-31a325be7f10">

We add a `rewards` field to `Vehicle` with a fake-populated field that's `1337 * 10^18`.

The goal here is to avoid messing with the existing stuff too much. We add a second "acceptable model type" for the GraphQL type `BigInt`:

https://github.com/DIMO-Network/identity-api/blob/a21867276a5d5f1afd8013aa29f6965e6122f2d2/gqlgen.yml#L90-L93

with an attached marshaler and unmarshaler (presently unused):

https://github.com/DIMO-Network/identity-api/blob/a21867276a5d5f1afd8013aa29f6965e6122f2d2/graph/types/blockchain.go#L66

The annoying part is that we have to make the model ourselves, so that we can override the type:

https://github.com/DIMO-Network/identity-api/blob/a21867276a5d5f1afd8013aa29f6965e6122f2d2/graph/model/models_custom.go#L6-L8

This looks innocent now, but as the objects grow I could see it becoming annoying.