### PR TITLE
SI-2159-filter-AD-by-beneficiary

### DIFF
--- a/graph/generated.go
+++ b/graph/generated.go
@@ -6821,7 +6821,7 @@ func (ec *executionContext) unmarshalInputAftermarketDevicesFilter(ctx context.C
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"owner"}
+	fieldsInOrder := [...]string{"owner", "beneficiary"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -6837,6 +6837,15 @@ func (ec *executionContext) unmarshalInputAftermarketDevicesFilter(ctx context.C
 				return it, err
 			}
 			it.Owner = data
+		case "beneficiary":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("beneficiary"))
+			data, err := ec.unmarshalOAddress2ᚖgithubᚗcomᚋethereumᚋgoᚑethereumᚋcommonᚐAddress(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Beneficiary = data
 		}
 	}
 

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -66,7 +66,8 @@ type AftermarketDeviceEdge struct {
 
 type AftermarketDevicesFilter struct {
 	// Filter for aftermarket devices owned by this address.
-	Owner *common.Address `json:"owner,omitempty"`
+	Owner       *common.Address `json:"owner,omitempty"`
+	Beneficiary *common.Address `json:"beneficiary,omitempty"`
 }
 
 // Represents a DIMO Canonical Name. Typically these are human-readable labels for

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -53,6 +53,7 @@ input AftermarketDevicesFilter {
   Filter for aftermarket devices owned by this address.
   """
   owner: Address
+  beneficiary: Address
 }
 
 type Query {

--- a/internal/repositories/aftermarket_devices.go
+++ b/internal/repositories/aftermarket_devices.go
@@ -54,8 +54,13 @@ func (r *Repository) GetAftermarketDevices(ctx context.Context, first *int, afte
 
 	where := []qm.QueryMod{}
 
-	if filterBy != nil && filterBy.Owner != nil {
-		where = append(where, models.AftermarketDeviceWhere.Owner.EQ(filterBy.Owner.Bytes()))
+	if filterBy != nil {
+		if filterBy.Owner != nil {
+			where = append(where, models.AftermarketDeviceWhere.Owner.EQ(filterBy.Owner.Bytes()))
+		}
+		if filterBy.Beneficiary != nil {
+			where = append(where, models.AftermarketDeviceWhere.Beneficiary.EQ(filterBy.Beneficiary.Bytes()))
+		}
 	}
 
 	adCount, err := models.AftermarketDevices(where...).Count(ctx, r.pdb.DBS().Reader)


### PR DESCRIPTION
[ticket](https://linear.app/dimo/issue/SI-2159/filter-aftermarket-devices-by-beneficiary)

- Allow clients to filter the aftermarket devices list by beneficiary