### PR TITLE
Change Url to URL in Go variables

### DIFF
--- a/internal/loader/aftermarket_device_loader.go
+++ b/internal/loader/aftermarket_device_loader.go
@@ -58,11 +58,11 @@ func (ad *AftermarketDeviceLoader) BatchGetLinkedAftermarketDeviceByVehicleID(ct
 	for i, vID := range vehicleIDs {
 		if am, ok := amByVehicleID[vID]; ok {
 			var retErr error
-			imageUrl, err := aftermarket.GetAftermarketDeviceImageUrl(ad.settings.BaseImageURL, am.ID)
+			imageURL, err := aftermarket.GetAftermarketDeviceImageURL(ad.settings.BaseImageURL, am.ID)
 			if err != nil {
 				retErr = errors.Join(retErr, fmt.Errorf("failed getting image url: %w", err))
 			}
-			obj, err := aftermarket.ToAPI(am, imageUrl)
+			obj, err := aftermarket.ToAPI(am, imageURL)
 			if err != nil {
 				retErr = errors.Join(retErr, fmt.Errorf("failed converting to API: %w", err))
 			}
@@ -99,11 +99,11 @@ func (ad *AftermarketDeviceLoader) BatchGetAftermarketDeviceByID(ctx context.Con
 	for i, adID := range aftermarketDeviceIDs {
 		var retErr error
 		if ads, ok := adByID[adID]; ok {
-			imageUrl, err := aftermarket.GetAftermarketDeviceImageUrl(ad.settings.BaseImageURL, ads.ID)
+			imageURL, err := aftermarket.GetAftermarketDeviceImageURL(ad.settings.BaseImageURL, ads.ID)
 			if err != nil {
 				retErr = errors.Join(retErr, fmt.Errorf("failed getting image url: %w", err))
 			}
-			obj, err := aftermarket.ToAPI(ads, imageUrl)
+			obj, err := aftermarket.ToAPI(ads, imageURL)
 			if err != nil {
 				retErr = errors.Join(retErr, fmt.Errorf("failed converting to API: %w", err))
 			}

--- a/internal/loader/vehicle_loader.go
+++ b/internal/loader/vehicle_loader.go
@@ -48,7 +48,7 @@ func (v *VehicleLoader) BatchGetVehicleByID(ctx context.Context, vehicleIDs []in
 	for i, k := range vehicleIDs {
 		if veh, ok := vehicleByID[k]; ok {
 			var retErr error
-			imageUrl, err := vehicle.GetVehicleImageUrl(v.settings.BaseImageURL, veh.ID)
+			imageUrl, err := vehicle.GetVehicleImageURL(v.settings.BaseImageURL, veh.ID)
 			if err != nil {
 				retErr = errors.Join(retErr, fmt.Errorf("error getting vehicle image url: %w", err))
 			}

--- a/internal/loader/vehicle_loader.go
+++ b/internal/loader/vehicle_loader.go
@@ -48,7 +48,7 @@ func (v *VehicleLoader) BatchGetVehicleByID(ctx context.Context, vehicleIDs []in
 	for i, k := range vehicleIDs {
 		if veh, ok := vehicleByID[k]; ok {
 			var retErr error
-			imageUrl, err := vehicle.GetVehicleImageURL(v.settings.BaseImageURL, veh.ID)
+			imageURL, err := vehicle.GetVehicleImageURL(v.settings.BaseImageURL, veh.ID)
 			if err != nil {
 				retErr = errors.Join(retErr, fmt.Errorf("error getting vehicle image url: %w", err))
 			}
@@ -56,7 +56,7 @@ func (v *VehicleLoader) BatchGetVehicleByID(ctx context.Context, vehicleIDs []in
 			if err != nil {
 				retErr = errors.Join(retErr, fmt.Errorf("error getting vehicle data uri: %w", err))
 			}
-			obj, err := vehicle.ToAPI(veh, imageUrl, dataURI)
+			obj, err := vehicle.ToAPI(veh, imageURL, dataURI)
 			if err != nil {
 				retErr = errors.Join(retErr, fmt.Errorf("error converting vehicle to API: %w", err))
 			}

--- a/internal/repositories/aftermarket/aftermarket_devices.go
+++ b/internal/repositories/aftermarket/aftermarket_devices.go
@@ -112,12 +112,12 @@ func (r *Repository) GetAftermarketDevices(ctx context.Context, first *int, afte
 	nodes := make([]*gmodel.AftermarketDevice, len(all))
 	var errList gqlerror.List
 	for i, da := range all {
-		imageUrl, err := GetAftermarketDeviceImageUrl(r.Settings.BaseImageURL, da.ID)
+		imageURL, err := GetAftermarketDeviceImageURL(r.Settings.BaseImageURL, da.ID)
 		if err != nil {
 			errList = append(errList, gqlerror.Errorf("error getting aftermarket device image url: %v", err))
 			continue
 		}
-		ga, err := ToAPI(da, imageUrl)
+		ga, err := ToAPI(da, imageURL)
 		if err != nil {
 			errList = append(errList, gqlerror.Errorf("error converting aftermarket device to API: %v", err))
 			continue
@@ -179,12 +179,12 @@ func (r *Repository) GetAftermarketDevice(ctx context.Context, by gmodel.Afterma
 		return nil, err
 	}
 
-	imageUrl, err := GetAftermarketDeviceImageUrl(r.Settings.BaseImageURL, ad.ID)
+	imageURL, err := GetAftermarketDeviceImageURL(r.Settings.BaseImageURL, ad.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image url: %w", err)
 	}
 
-	return ToAPI(ad, imageUrl)
+	return ToAPI(ad, imageURL)
 }
 
 type aftermarketDevicePrimaryKey struct {
@@ -192,7 +192,7 @@ type aftermarketDevicePrimaryKey struct {
 }
 
 // ToAPI converts a vehicle to a corresponding API vehicle.
-func ToAPI(d *models.AftermarketDevice, imageUrl string) (*gmodel.AftermarketDevice, error) {
+func ToAPI(d *models.AftermarketDevice, imageURL string) (*gmodel.AftermarketDevice, error) {
 	globalID, err := base.EncodeGlobalTokenID(TokenPrefix, d.ID)
 	if err != nil {
 		return nil, fmt.Errorf("error encoding vehicle id: %w", err)
@@ -215,11 +215,11 @@ func ToAPI(d *models.AftermarketDevice, imageUrl string) (*gmodel.AftermarketDev
 		ClaimedAt:      d.ClaimedAt.Ptr(),
 		ManufacturerID: d.ManufacturerID.Ptr(),
 		Name:           name,
-		Image:          imageUrl,
+		Image:          imageURL,
 	}, nil
 }
 
-func GetAftermarketDeviceImageUrl(baseURL string, tokenID int) (string, error) {
+func GetAftermarketDeviceImageURL(baseURL string, tokenID int) (string, error) {
 	tokenStr := strconv.Itoa(tokenID)
 	return url.JoinPath(baseURL, "aftermarket", "device", tokenStr, "image")
 }

--- a/internal/repositories/aftermarket/aftermarket_devices_test.go
+++ b/internal/repositories/aftermarket/aftermarket_devices_test.go
@@ -312,7 +312,7 @@ func Test_GetAftermarketDeviceImageUrl(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		url, err := GetAftermarketDeviceImageUrl(tc.baseURL, tc.tokenID)
+		url, err := GetAftermarketDeviceImageURL(tc.baseURL, tc.tokenID)
 		require.NoError(t, err)
 		require.Equal(t, tc.expectedURL, url)
 	}

--- a/internal/repositories/vehicle/vehicles.go
+++ b/internal/repositories/vehicle/vehicles.go
@@ -42,7 +42,7 @@ func (r *Repository) createVehiclesResponse(totalCount int64, vehicles models.Ve
 	nodes := make([]*gmodel.Vehicle, len(vehicles))
 
 	for i, dv := range vehicles {
-		imageUrl, err := GetVehicleImageURL(r.Settings.BaseImageURL, dv.ID)
+		imageURL, err := GetVehicleImageURL(r.Settings.BaseImageURL, dv.ID)
 		if err != nil {
 			wErr := fmt.Errorf("error getting vehicle image url: %w", err)
 			errList = append(errList, gqlerror.Wrap(wErr))
@@ -54,7 +54,7 @@ func (r *Repository) createVehiclesResponse(totalCount int64, vehicles models.Ve
 			errList = append(errList, gqlerror.Wrap(wErr))
 			continue
 		}
-		gv, err := ToAPI(dv, imageUrl, dataURI)
+		gv, err := ToAPI(dv, imageURL, dataURI)
 		if err != nil {
 			wErr := fmt.Errorf("error converting vehicle to API: %w", err)
 			errList = append(errList, gqlerror.Wrap(wErr))
@@ -176,7 +176,7 @@ func (r *Repository) GetVehicle(ctx context.Context, id int) (*gmodel.Vehicle, e
 	if err != nil {
 		return nil, err
 	}
-	imageUrl, err := GetVehicleImageURL(r.Settings.BaseImageURL, v.ID)
+	imageURL, err := GetVehicleImageURL(r.Settings.BaseImageURL, v.ID)
 	if err != nil {
 		return nil, fmt.Errorf("error getting vehicle image url: %w", err)
 	}
@@ -184,7 +184,7 @@ func (r *Repository) GetVehicle(ctx context.Context, id int) (*gmodel.Vehicle, e
 	if err != nil {
 		return nil, fmt.Errorf("error getting vehicle data uri: %w", err)
 	}
-	return ToAPI(v, imageUrl, dataURI)
+	return ToAPI(v, imageURL, dataURI)
 }
 
 // queryModsFromFilters returns a slice of query mods from the given filters.
@@ -234,7 +234,7 @@ func queryModsFromFilters(filter *gmodel.VehiclesFilter) []qm.QueryMod {
 }
 
 // ToAPI converts a vehicle to a corresponding graphql model.
-func ToAPI(v *models.Vehicle, imageUrl string, dataURI string) (*gmodel.Vehicle, error) {
+func ToAPI(v *models.Vehicle, imageURL string, dataURI string) (*gmodel.Vehicle, error) {
 	nameList := mnemonic.FromInt32WithObfuscation(int32(v.ID))
 	name := strings.Join(nameList, " ")
 
@@ -256,7 +256,7 @@ func ToAPI(v *models.Vehicle, imageUrl string, dataURI string) (*gmodel.Vehicle,
 		},
 		ManufacturerID: v.ManufacturerID.Ptr(),
 		Name:           name,
-		Image:          imageUrl,
+		Image:          imageURL,
 		DataURI:        dataURI,
 	}, nil
 }

--- a/internal/repositories/vehicle/vehicles.go
+++ b/internal/repositories/vehicle/vehicles.go
@@ -42,7 +42,7 @@ func (r *Repository) createVehiclesResponse(totalCount int64, vehicles models.Ve
 	nodes := make([]*gmodel.Vehicle, len(vehicles))
 
 	for i, dv := range vehicles {
-		imageUrl, err := GetVehicleImageUrl(r.Settings.BaseImageURL, dv.ID)
+		imageUrl, err := GetVehicleImageURL(r.Settings.BaseImageURL, dv.ID)
 		if err != nil {
 			wErr := fmt.Errorf("error getting vehicle image url: %w", err)
 			errList = append(errList, gqlerror.Wrap(wErr))
@@ -176,7 +176,7 @@ func (r *Repository) GetVehicle(ctx context.Context, id int) (*gmodel.Vehicle, e
 	if err != nil {
 		return nil, err
 	}
-	imageUrl, err := GetVehicleImageUrl(r.Settings.BaseImageURL, v.ID)
+	imageUrl, err := GetVehicleImageURL(r.Settings.BaseImageURL, v.ID)
 	if err != nil {
 		return nil, fmt.Errorf("error getting vehicle image url: %w", err)
 	}
@@ -261,8 +261,8 @@ func ToAPI(v *models.Vehicle, imageUrl string, dataURI string) (*gmodel.Vehicle,
 	}, nil
 }
 
-// GetVehicleImageUrl craates a URL for the vehicle image.
-func GetVehicleImageUrl(baseURL string, tokenID int) (string, error) {
+// GetVehicleImageURL craates a URL for the vehicle image.
+func GetVehicleImageURL(baseURL string, tokenID int) (string, error) {
 	tokenStr := strconv.Itoa(tokenID)
 	return url.JoinPath(baseURL, "vehicle", tokenStr, "image")
 }

--- a/internal/repositories/vehicle/vehicles_test.go
+++ b/internal/repositories/vehicle/vehicles_test.go
@@ -90,7 +90,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_Success() {
 	_, wallet2, err := test.GenerateWallet()
 	o.NoError(err)
 
-	ddfUrl := []string{
+	ddfURL := []string{
 		"http://some-url.com",
 		"http://some-url-2.com",
 	}
@@ -104,7 +104,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_Success() {
 			Model:         camry,
 			Year:          year2020,
 			MintedAt:      currTime,
-			DefinitionURI: null.StringFrom(ddfUrl[0]),
+			DefinitionURI: null.StringFrom(ddfURL[0]),
 		},
 		{
 			ID:            2,
@@ -113,7 +113,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_Success() {
 			Model:         camry,
 			Year:          year2022,
 			MintedAt:      currTime,
-			DefinitionURI: null.StringFrom(ddfUrl[1]),
+			DefinitionURI: null.StringFrom(ddfURL[1]),
 		},
 	}
 
@@ -154,7 +154,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_Success() {
 				Owner:    common.BytesToAddress(wallet.Bytes()),
 				MintedAt: vehicles[1].MintedAt,
 				Definition: &gmodel.Definition{
-					URI:   &ddfUrl[1],
+					URI:   &ddfURL[1],
 					Make:  &vehicles[1].Make.String,
 					Model: &vehicles[1].Model.String,
 					Year:  &vehicles[1].Year.Int,
@@ -171,7 +171,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_Success() {
 				Owner:    common.BytesToAddress(wallet.Bytes()),
 				MintedAt: vehicles[0].MintedAt,
 				Definition: &gmodel.Definition{
-					URI:   &ddfUrl[0],
+					URI:   &ddfURL[0],
 					Make:  &vehicles[0].Make.String,
 					Model: &vehicles[0].Model.String,
 					Year:  &vehicles[0].Year.Int,
@@ -194,7 +194,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_Pagination(
 	_, wallet, err := test.GenerateWallet()
 	o.NoError(err)
 
-	ddfUrl := []string{
+	ddfURL := []string{
 		"http://some-url.com",
 		"http://some-url-2.com",
 	}
@@ -208,7 +208,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_Pagination(
 			Model:         camry,
 			Year:          year2020,
 			MintedAt:      currTime,
-			DefinitionURI: null.StringFrom(ddfUrl[0]),
+			DefinitionURI: null.StringFrom(ddfURL[0]),
 		},
 		{
 			ID:            2,
@@ -217,7 +217,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_Pagination(
 			Model:         camry,
 			Year:          year2022,
 			MintedAt:      currTime,
-			DefinitionURI: null.StringFrom(ddfUrl[1]),
+			DefinitionURI: null.StringFrom(ddfURL[1]),
 		},
 	}
 
@@ -242,7 +242,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_Pagination(
 				Owner:    common.BytesToAddress(wallet.Bytes()),
 				MintedAt: vehicles[1].MintedAt,
 				Definition: &gmodel.Definition{
-					URI:   &ddfUrl[1],
+					URI:   &ddfURL[1],
 					Make:  &vehicles[1].Make.String,
 					Model: &vehicles[1].Model.String,
 					Year:  &vehicles[1].Year.Int,
@@ -265,7 +265,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_Pagination_
 	_, wallet, err := test.GenerateWallet()
 	o.NoError(err)
 
-	ddfUrl := []string{
+	ddfURL := []string{
 		"http://some-url.com",
 		"http://some-url-2.com",
 	}
@@ -279,7 +279,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_Pagination_
 			Model:         camry,
 			Year:          year2020,
 			MintedAt:      currTime,
-			DefinitionURI: null.StringFrom(ddfUrl[0]),
+			DefinitionURI: null.StringFrom(ddfURL[0]),
 		},
 		{
 			ID:            2,
@@ -288,7 +288,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_Pagination_
 			Model:         camry,
 			Year:          year2022,
 			MintedAt:      currTime,
-			DefinitionURI: null.StringFrom(ddfUrl[1]),
+			DefinitionURI: null.StringFrom(ddfURL[1]),
 		},
 	}
 
@@ -314,7 +314,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_Pagination_
 				Owner:    common.BytesToAddress(wallet.Bytes()),
 				MintedAt: vehicles[0].MintedAt,
 				Definition: &gmodel.Definition{
-					URI:   &ddfUrl[0],
+					URI:   &ddfURL[0],
 					Make:  &vehicles[0].Make.String,
 					Model: &vehicles[0].Model.String,
 					Year:  &vehicles[0].Year.Int,
@@ -340,7 +340,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_OwnedByUser
 	_, wallet2, err := test.GenerateWallet()
 	o.NoError(err)
 
-	ddfUrl := []string{
+	ddfURL := []string{
 		"http://some-url.com",
 		"http://some-url-2.com",
 	}
@@ -354,7 +354,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_OwnedByUser
 			Model:         camry,
 			Year:          year2020,
 			MintedAt:      currTime,
-			DefinitionURI: null.StringFrom(ddfUrl[0]),
+			DefinitionURI: null.StringFrom(ddfURL[0]),
 		},
 		{
 			ID:            2,
@@ -363,7 +363,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_OwnedByUser
 			Model:         camry,
 			Year:          year2022,
 			MintedAt:      currTime,
-			DefinitionURI: null.StringFrom(ddfUrl[1]),
+			DefinitionURI: null.StringFrom(ddfURL[1]),
 		},
 	}
 
@@ -404,7 +404,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_OwnedByUser
 				Owner:    common.BytesToAddress(wallet2.Bytes()),
 				MintedAt: vehicles[1].MintedAt,
 				Definition: &gmodel.Definition{
-					URI:   &ddfUrl[1],
+					URI:   &ddfURL[1],
 					Make:  &vehicles[1].Make.String,
 					Model: &vehicles[1].Model.String,
 					Year:  &vehicles[1].Year.Int,
@@ -421,7 +421,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehicles_OwnedByUser
 				Owner:    common.BytesToAddress(wallet.Bytes()),
 				MintedAt: vehicles[0].MintedAt,
 				Definition: &gmodel.Definition{
-					URI:   &ddfUrl[0],
+					URI:   &ddfURL[0],
 					Make:  &vehicles[0].Make.String,
 					Model: &vehicles[0].Model.String,
 					Year:  &vehicles[0].Year.Int,
@@ -447,7 +447,7 @@ func (o *AccessibleVehiclesRepoTestSuite) TestVehiclesMultiplePrivsOnOne() {
 	_, wallet2, err := test.GenerateWallet()
 	o.NoError(err)
 
-	ddfUrl := []string{
+	ddfURL := []string{
 		"http://some-url.com",
 		"http://some-url-2.com",
 	}
@@ -461,7 +461,7 @@ func (o *AccessibleVehiclesRepoTestSuite) TestVehiclesMultiplePrivsOnOne() {
 			Model:         camry,
 			Year:          year2020,
 			MintedAt:      currTime,
-			DefinitionURI: null.StringFrom(ddfUrl[0]),
+			DefinitionURI: null.StringFrom(ddfURL[0]),
 		},
 		{
 			ID:            2,
@@ -470,7 +470,7 @@ func (o *AccessibleVehiclesRepoTestSuite) TestVehiclesMultiplePrivsOnOne() {
 			Model:         camry,
 			Year:          year2022,
 			MintedAt:      currTime,
-			DefinitionURI: null.StringFrom(ddfUrl[1]),
+			DefinitionURI: null.StringFrom(ddfURL[1]),
 		},
 	}
 
@@ -518,7 +518,7 @@ func (o *AccessibleVehiclesRepoTestSuite) TestVehiclesMultiplePrivsOnOne() {
 				Owner:    common.BytesToAddress(wallet2.Bytes()),
 				MintedAt: vehicles[1].MintedAt,
 				Definition: &gmodel.Definition{
-					URI:   &ddfUrl[1],
+					URI:   &ddfURL[1],
 					Make:  &vehicles[1].Make.String,
 					Model: &vehicles[1].Model.String,
 					Year:  &vehicles[1].Year.Int,
@@ -535,7 +535,7 @@ func (o *AccessibleVehiclesRepoTestSuite) TestVehiclesMultiplePrivsOnOne() {
 				Owner:    common.BytesToAddress(wallet.Bytes()),
 				MintedAt: vehicles[0].MintedAt,
 				Definition: &gmodel.Definition{
-					URI:   &ddfUrl[0],
+					URI:   &ddfURL[0],
 					Make:  &vehicles[0].Make.String,
 					Model: &vehicles[0].Model.String,
 					Year:  &vehicles[0].Year.Int,
@@ -990,7 +990,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehiclesFilters() {
 		Year:         year2020,
 		MintedAt:     currTime,
 	}
-	vehicle1ImageURL, err := GetVehicleImageUrl(o.settings.BaseImageURL, testVehicle1.ID)
+	vehicle1ImageURL, err := GetVehicleImageURL(o.settings.BaseImageURL, testVehicle1.ID)
 	o.Require().NoError(err)
 	vehicle1DataURI, err := GetVehicleDataURI(o.settings.BaseVehicleDataURI, testVehicle1.ID)
 	o.Require().NoError(err)
@@ -1005,7 +1005,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehiclesFilters() {
 		Year:         year2022,
 		MintedAt:     currTime,
 	}
-	vehicle2ImageURL, err := GetVehicleImageUrl(o.settings.BaseImageURL, testVehicle2.ID)
+	vehicle2ImageURL, err := GetVehicleImageURL(o.settings.BaseImageURL, testVehicle2.ID)
 	o.Require().NoError(err)
 	vehicle2DataURI, err := GetVehicleDataURI(o.settings.BaseVehicleDataURI, testVehicle2.ID)
 	o.Require().NoError(err)
@@ -1020,7 +1020,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehiclesFilters() {
 		Year:         year2022,
 		MintedAt:     currTime,
 	}
-	vehicle3ImageURL, err := GetVehicleImageUrl(o.settings.BaseImageURL, testVehicle3.ID)
+	vehicle3ImageURL, err := GetVehicleImageURL(o.settings.BaseImageURL, testVehicle3.ID)
 	o.Require().NoError(err)
 	vehicle3DataURI, err := GetVehicleDataURI(o.settings.BaseVehicleDataURI, testVehicle3.ID)
 	o.Require().NoError(err)
@@ -1035,7 +1035,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehiclesFilters() {
 		Year:         year2020,
 		MintedAt:     currTime,
 	}
-	vehicle4ImageURL, err := GetVehicleImageUrl(o.settings.BaseImageURL, testVehicle4.ID)
+	vehicle4ImageURL, err := GetVehicleImageURL(o.settings.BaseImageURL, testVehicle4.ID)
 	o.Require().NoError(err)
 	vehicle4DataURI, err := GetVehicleDataURI(o.settings.BaseVehicleDataURI, testVehicle4.ID)
 	o.Require().NoError(err)

--- a/internal/services/contract_events_consumer_test.go
+++ b/internal/services/contract_events_consumer_test.go
@@ -555,7 +555,7 @@ func TestHandle_SyntheticDeviceNodeBurnedEvent_Success(t *testing.T) {
 	assert.Empty(t, sds)
 }
 
-func TestHandle_DefinitionUriAttribute_Event_Success(t *testing.T) {
+func TestHandle_DefinitionURIAttribute_Event_Success(t *testing.T) {
 	ctx := context.Background()
 	logger := zerolog.New(os.Stdout).With().Timestamp().Str("app", helpers.DBSettings.Name).Logger()
 	contractEventData.EventName = string(VehicleAttributeSet)
@@ -596,19 +596,19 @@ func TestHandle_DefinitionUriAttribute_Event_Success(t *testing.T) {
 	err = sd.Insert(ctx, pdb.DBS().Writer.DB, boil.Infer())
 	assert.NoError(t, err)
 
-	mockDefUri := "http://someurl.com/someid"
+	mockDefURI := "http://someurl.com/someid"
 	// http client mock
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	respJSON := fmt.Sprintf(`{ "type": { "make":"%s", "model":"%s", "year":%d }}`, "Toyota", "Camry", 2020)
 
-	httpmock.RegisterResponder(http.MethodGet, mockDefUri, httpmock.NewStringResponder(200, respJSON))
+	httpmock.RegisterResponder(http.MethodGet, mockDefURI, httpmock.NewStringResponder(200, respJSON))
 
 	tkID := big.NewInt(1)
 	eventData := VehicleAttributeSetData{
 		TokenID:   tkID,
 		Attribute: "DefinitionURI",
-		Info:      mockDefUri,
+		Info:      mockDefURI,
 	}
 	settings := config.Settings{
 		DIMORegistryAddr:    contractEventData.Contract.String(),


### PR DESCRIPTION
Change `xUri` to `xURI`.

I may not remember everything from the style guide but I always remember this for some reason.