### PR TITLE
Consume manufacturer table events

### DIFF
--- a/internal/services/contract_events_consumer_test.go
+++ b/internal/services/contract_events_consumer_test.go
@@ -1085,7 +1085,7 @@ func Test_HandleVehicle_Transferred_To_Zero_Event_NoDelete_AfterMarketDevice(t *
 	assert.Equal(t, vehicle.OwnerAddress, veh[0].OwnerAddress)
 }
 
-func getCommonEntities(ctx context.Context, vehicleID, aftermarketDeviceID, syntheticDeviceID int, owner, beneficiary common.Address) (models.Manufacturer, models.Manufacturer, models.Vehicle, models.AftermarketDevice, models.SyntheticDevice) {
+func getCommonEntities(_ context.Context, vehicleID, aftermarketDeviceID, syntheticDeviceID int, owner, beneficiary common.Address) (models.Manufacturer, models.Manufacturer, models.Vehicle, models.AftermarketDevice, models.SyntheticDevice) {
 	mfr := models.Manufacturer{
 		ID:       130,
 		Name:     "Tesla",

--- a/internal/services/contracts_events_consumer.go
+++ b/internal/services/contracts_events_consumer.go
@@ -31,26 +31,41 @@ type EventName string
 var zeroAddress common.Address
 
 const (
-	Transfer                             EventName = "Transfer"
-	VehicleAttributeSet                  EventName = "VehicleAttributeSet"
-	ManufacturerNodeMinted               EventName = "ManufacturerNodeMinted"
-	AftermarketDeviceAttributeSet        EventName = "AftermarketDeviceAttributeSet"
-	PrivilegeSet                         EventName = "PrivilegeSet"
-	AftermarketDeviceClaimed             EventName = "AftermarketDeviceClaimed"
-	AftermarketDevicePaired              EventName = "AftermarketDevicePaired"
-	AftermarketDeviceUnpaired            EventName = "AftermarketDeviceUnpaired"
-	BeneficiarySetEvent                  EventName = "BeneficiarySet"
-	VehicleNodeMinted                    EventName = "VehicleNodeMinted"
-	AftermarketDeviceNodeMinted          EventName = "AftermarketDeviceNodeMinted"
-	SyntheticDeviceNodeMinted            EventName = "SyntheticDeviceNodeMinted"
-	SyntheticDeviceNodeBurned            EventName = "SyntheticDeviceNodeBurned"
-	NewNode                              EventName = "NewNode"
-	NewExpiration                        EventName = "NewExpiration"
-	NameChanged                          EventName = "NameChanged"
-	VehicleIdChanged                     EventName = "VehicleIdChanged"
+	// All NFTs.
+	Transfer            EventName = "Transfer"
+	PrivilegeSet        EventName = "PrivilegeSet"
+	BeneficiarySetEvent EventName = "BeneficiarySet"
+
+	// Manufacturers.
+	ManufacturerNodeMinted       EventName = "ManufacturerNodeMinted"
+	DeviceDefinitionTableCreated EventName = "DeviceDefinitionTableCreated"
+	ManufacturerTableSet         EventName = "ManufacturerTableSet"
+
+	// Aftermarket devices.
+	AftermarketDeviceNodeMinted   EventName = "AftermarketDeviceNodeMinted"
+	AftermarketDeviceAttributeSet EventName = "AftermarketDeviceAttributeSet"
+	AftermarketDeviceClaimed      EventName = "AftermarketDeviceClaimed"
+	AftermarketDevicePaired       EventName = "AftermarketDevicePaired"
+	AftermarketDeviceUnpaired     EventName = "AftermarketDeviceUnpaired"
+	AftermarketDeviceAddressReset EventName = "AftermarketDeviceAddressReset"
+
+	// Vehicles.
+	VehicleNodeMinted   EventName = "VehicleNodeMinted"
+	VehicleAttributeSet EventName = "VehicleAttributeSet"
+
+	// Synthetic devices.
+	SyntheticDeviceNodeMinted EventName = "SyntheticDeviceNodeMinted"
+	SyntheticDeviceNodeBurned EventName = "SyntheticDeviceNodeBurned"
+
+	// DCNs.
+	NewNode          EventName = "NewNode"
+	NewExpiration    EventName = "NewExpiration"
+	NameChanged      EventName = "NameChanged"
+	VehicleIdChanged EventName = "VehicleIdChanged"
+
+	// Rewards.
 	TokensTransferredForDevice           EventName = "TokensTransferredForDevice"
 	TokensTransferredForConnectionStreak EventName = "TokensTransferredForConnectionStreak"
-	AftermarketDeviceAddressReset        EventName = "AftermarketDeviceAddressReset"
 )
 
 func (r EventName) String() string {
@@ -101,6 +116,10 @@ func (c *ContractsEventsConsumer) Process(ctx context.Context, event *shared.Clo
 		switch eventName {
 		case ManufacturerNodeMinted:
 			return c.handleManufacturerNodeMintedEvent(ctx, &data)
+		case DeviceDefinitionTableCreated:
+			return c.handleDeviceDefinitionTableCreated(ctx, &data)
+		case ManufacturerTableSet:
+			return c.handleManufacturerTableSet(ctx, &data)
 
 		case VehicleNodeMinted:
 			return c.handleVehicleNodeMintedEvent(ctx, &data)
@@ -182,6 +201,36 @@ func (c *ContractsEventsConsumer) handleManufacturerNodeMintedEvent(ctx context.
 	}
 
 	return mfr.Upsert(ctx, c.dbs.DBS().Writer, false, []string{models.ManufacturerColumns.ID}, boil.None(), boil.Infer())
+}
+
+func (c *ContractsEventsConsumer) handleDeviceDefinitionTableCreated(ctx context.Context, e *ContractEventData) error {
+	var args DeviceDefinitionTableCreatedData
+	if err := json.Unmarshal(e.Arguments, &args); err != nil {
+		return err
+	}
+
+	mfr := models.Manufacturer{
+		ID:      int(args.ManufacturerId.Int64()),
+		TableID: null.IntFrom(int(args.TableId.Int64())),
+	}
+
+	_, err := mfr.Update(ctx, c.dbs.DBS().Writer, boil.Whitelist(models.ManufacturerColumns.TableID))
+	return err
+}
+
+func (c *ContractsEventsConsumer) handleManufacturerTableSet(ctx context.Context, e *ContractEventData) error {
+	var args ManufacturerTableSetData
+	if err := json.Unmarshal(e.Arguments, &args); err != nil {
+		return err
+	}
+
+	mfr := models.Manufacturer{
+		ID:      int(args.ManufacturerId.Int64()),
+		TableID: null.IntFrom(int(args.TableId.Int64())),
+	}
+
+	_, err := mfr.Update(ctx, c.dbs.DBS().Writer, boil.Whitelist(models.ManufacturerColumns.TableID))
+	return err
 }
 
 func (c *ContractsEventsConsumer) handleVehicleNodeMintedEvent(ctx context.Context, e *ContractEventData) error {

--- a/internal/services/event_data_models.go
+++ b/internal/services/event_data_models.go
@@ -150,3 +150,14 @@ type AftermarketDeviceAddressResetData struct {
 	TokenId                  *big.Int
 	AftermarketDeviceAddress common.Address
 }
+
+type ManufacturerTableSetData struct {
+	ManufacturerId *big.Int
+	TableId        *big.Int
+}
+
+type DeviceDefinitionTableCreatedData struct {
+	TableOwner     common.Address
+	ManufacturerId *big.Int
+	TableId        *big.Int
+}

--- a/migrations/00027_add_manufacturer_table_id.sql
+++ b/migrations/00027_add_manufacturer_table_id.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE manufacturers
+    ADD COLUMN table_id int;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE manufacturers
+    DROP COLUMN table_id;
+-- +goose StatementEnd

--- a/models/manufacturers.go
+++ b/models/manufacturers.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/friendsofgo/errors"
+	"github.com/volatiletech/null/v8"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"github.com/volatiletech/sqlboiler/v4/queries"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
@@ -27,6 +28,7 @@ type Manufacturer struct {
 	Name     string    `boil:"name" json:"name" toml:"name" yaml:"name"`
 	Owner    []byte    `boil:"owner" json:"owner" toml:"owner" yaml:"owner"`
 	MintedAt time.Time `boil:"minted_at" json:"minted_at" toml:"minted_at" yaml:"minted_at"`
+	TableID  null.Int  `boil:"table_id" json:"table_id,omitempty" toml:"table_id" yaml:"table_id,omitempty"`
 
 	R *manufacturerR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L manufacturerL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -37,11 +39,13 @@ var ManufacturerColumns = struct {
 	Name     string
 	Owner    string
 	MintedAt string
+	TableID  string
 }{
 	ID:       "id",
 	Name:     "name",
 	Owner:    "owner",
 	MintedAt: "minted_at",
+	TableID:  "table_id",
 }
 
 var ManufacturerTableColumns = struct {
@@ -49,11 +53,13 @@ var ManufacturerTableColumns = struct {
 	Name     string
 	Owner    string
 	MintedAt string
+	TableID  string
 }{
 	ID:       "manufacturers.id",
 	Name:     "manufacturers.name",
 	Owner:    "manufacturers.owner",
 	MintedAt: "manufacturers.minted_at",
+	TableID:  "manufacturers.table_id",
 }
 
 // Generated where
@@ -90,11 +96,13 @@ var ManufacturerWhere = struct {
 	Name     whereHelperstring
 	Owner    whereHelper__byte
 	MintedAt whereHelpertime_Time
+	TableID  whereHelpernull_Int
 }{
 	ID:       whereHelperint{field: "\"identity_api\".\"manufacturers\".\"id\""},
 	Name:     whereHelperstring{field: "\"identity_api\".\"manufacturers\".\"name\""},
 	Owner:    whereHelper__byte{field: "\"identity_api\".\"manufacturers\".\"owner\""},
 	MintedAt: whereHelpertime_Time{field: "\"identity_api\".\"manufacturers\".\"minted_at\""},
+	TableID:  whereHelpernull_Int{field: "\"identity_api\".\"manufacturers\".\"table_id\""},
 }
 
 // ManufacturerRels is where relationship names are stored.
@@ -135,9 +143,9 @@ func (r *manufacturerR) GetVehicles() VehicleSlice {
 type manufacturerL struct{}
 
 var (
-	manufacturerAllColumns            = []string{"id", "name", "owner", "minted_at"}
+	manufacturerAllColumns            = []string{"id", "name", "owner", "minted_at", "table_id"}
 	manufacturerColumnsWithoutDefault = []string{"id", "name", "owner", "minted_at"}
-	manufacturerColumnsWithDefault    = []string{}
+	manufacturerColumnsWithDefault    = []string{"table_id"}
 	manufacturerPrimaryKeyColumns     = []string{"id"}
 	manufacturerGeneratedColumns      = []string{}
 )


### PR DESCRIPTION
Read in the `ManufacturerTableSet` and `DeviceDefinitionTableCreated` events from the registry, and use these to populate a new field `table_id` on the `manufacturers` table.