### PR TITLE
Fix query tableland when metadata is empty

### DIFF
--- a/internal/helpers/test.go
+++ b/internal/helpers/test.go
@@ -34,9 +34,9 @@ func StartContainerDatabase(ctx context.Context, t *testing.T, migrationsDirRelP
 
 	var err error
 
-	container, err = postgres.RunContainer(
+	container, err = postgres.Run(
 		ctx,
-		testcontainers.WithImage("docker.io/postgres:14.10-alpine"),
+		"docker.io/postgres:14.10-alpine",
 		postgres.WithDatabase("identity_api"),
 		postgres.WithUsername("dimo"),
 		postgres.WithPassword("dimo"),

--- a/internal/repositories/devicedefinition/devicedefinition_test.go
+++ b/internal/repositories/devicedefinition/devicedefinition_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/volatiletech/null/v8"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"net/http"
@@ -84,13 +85,15 @@ func Test_GetDeviceDefinitions_Query(t *testing.T) {
 		"metadata": ""
 	  }
 	]`
+	// when we query against tableland, if metadata is not set, it is returned as an empty string ""
 	var modelQueryTablelandResponse []DeviceDefinitionTablelandModel
-	_ = json.Unmarshal([]byte(respQueryBody), &modelQueryTablelandResponse)
+	errUm := json.Unmarshal([]byte(respQueryBody), &modelQueryTablelandResponse)
+	require.NoError(t, errUm)
 
 	httpmock.RegisterResponder(http.MethodGet, baseURL+queryURL, httpmock.NewStringResponder(200, respQueryBody))
 
 	res, err := adController.GetDeviceDefinitions(ctx, &mfr.TableID.Int, nil, nil, &last, &before, &model.DeviceDefinitionFilter{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, res.Edges, 2)
 	assert.Equal(t, res.TotalCount, 4)

--- a/internal/repositories/devicedefinition/devicedefinition_test.go
+++ b/internal/repositories/devicedefinition/devicedefinition_test.go
@@ -81,14 +81,7 @@ func Test_GetDeviceDefinitions_Query(t *testing.T) {
 		"deviceType": "vehicle",
 		"imageURI": "https://image",
 		"ksuid": "12G3iFH7Xc9Wvsw7pg6sD7uzoKK",
-		"metadata": {
-		  "device_attributes": [
-			{
-			  "name": "powertrain_type",
-			  "value": "EV"
-			}
-		  ]
-		}
+		"metadata": ""
 	  }
 	]`
 	var modelQueryTablelandResponse []DeviceDefinitionTablelandModel


### PR DESCRIPTION
Metadata may not always be filled in. Currently this happens with aftermarket devices since we don't have any particular metadata we need for them. With vehicles we pretty much always have at least powertrain_type filled in.

This adds a custom unmarshaller for the Device Definition model that can handle the "" string for metadata, and I updated the test as well to validate it works. 