### PR TITLE
Ex 3236 filter stakes by attachability

### DIFF
--- a/graph/generated.go
+++ b/graph/generated.go
@@ -17563,7 +17563,7 @@ func (ec *executionContext) unmarshalInputStakeFilterBy(ctx context.Context, obj
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"owner"}
+	fieldsInOrder := [...]string{"owner", "attachable"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -17577,6 +17577,13 @@ func (ec *executionContext) unmarshalInputStakeFilterBy(ctx context.Context, obj
 				return it, err
 			}
 			it.Owner = data
+		case "attachable":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("attachable"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Attachable = data
 		}
 	}
 

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -458,8 +458,10 @@ type StakeEdge struct {
 }
 
 type StakeFilterBy struct {
-	Owner      *common.Address `json:"owner,omitempty"`
-	Attachable *bool           `json:"attachable,omitempty"`
+	Owner *common.Address `json:"owner,omitempty"`
+	// Filter stakes based on attachability. A stake is considered attachable if it
+	// is not presently attached to a vehicle and has not yet ended.
+	Attachable *bool `json:"attachable,omitempty"`
 }
 
 // The SyntheticDevice is a software connection established to connect the vehicle to the DIMO network.

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -458,7 +458,8 @@ type StakeEdge struct {
 }
 
 type StakeFilterBy struct {
-	Owner *common.Address `json:"owner,omitempty"`
+	Owner      *common.Address `json:"owner,omitempty"`
+	Attachable *bool           `json:"attachable,omitempty"`
 }
 
 // The SyntheticDevice is a software connection established to connect the vehicle to the DIMO network.

--- a/graph/schema/stakes.graphqls
+++ b/graph/schema/stakes.graphqls
@@ -15,6 +15,10 @@ extend type Query {
 
 input StakeFilterBy {
   owner: Address
+  """
+  Filter stakes based on attachability. A stake is considered attachable if it
+  is not presently attached to a vehicle and has not yet ended.
+  """
   attachable: Boolean
 }
 

--- a/graph/schema/stakes.graphqls
+++ b/graph/schema/stakes.graphqls
@@ -15,6 +15,7 @@ extend type Query {
 
 input StakeFilterBy {
   owner: Address
+  attachable: Boolean
 }
 
 type Stake {


### PR DESCRIPTION
Allow clients to filter stakes by "attachability"
```graphql
{
  stakes(first: 10, filterBy: {attachable: true}) {
    # …
  }
}
```
Here a stake is "attachable" if and only if

1. It's not attached to a vehicle
2. It hasn't ended; in particular, it hasn't been withdrawn