### PR TITLE
Align stake level numbers between Solidity and GraphQL

### DIFF
--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -433,10 +433,12 @@ type Stake struct {
 	// The token id of the license as an NFT.
 	TokenID int `json:"tokenId"`
 	// The owner of the license. A single owner can own multiple licenses.
-	Owner  common.Address `json:"owner"`
-	Level  int            `json:"level"`
-	Points int            `json:"points"`
-	Amount *decimal.Big   `json:"amount"`
+	Owner common.Address `json:"owner"`
+	// Level is the level of the stake. Presently the levels are 0, 1, 2. These translate
+	// to Levels 2, 3, 4 in the DIP. See https://docs.dimo.org/governance/improvement-proposals/dip2
+	Level  int          `json:"level"`
+	Points int          `json:"points"`
+	Amount *decimal.Big `json:"amount"`
 	// The block timestamp for the transaction that minted this stake.
 	StakedAt    time.Time  `json:"stakedAt"`
 	EndsAt      time.Time  `json:"endsAt"`

--- a/graph/schema/stakes.graphqls
+++ b/graph/schema/stakes.graphqls
@@ -31,6 +31,10 @@ type Stake {
   The owner of the license. A single owner can own multiple licenses.
   """
   owner: Address!
+  """
+  Level is the level of the stake. Presently the levels are 0, 1, 2. These translate
+  to Levels 2, 3, 4 in the DIP. See https://docs.dimo.org/governance/improvement-proposals/dip2
+  """
   level: Int!
   points: Int!
   amount: BigDecimal!

--- a/internal/repositories/stake/stake.go
+++ b/internal/repositories/stake/stake.go
@@ -30,7 +30,7 @@ func ToAPI(v *models.Stake) *gmodel.Stake {
 	return &gmodel.Stake{
 		TokenID:     v.ID,
 		Owner:       common.BytesToAddress(v.Owner),
-		Level:       v.Level + 2, // TODO(elffjs): Is this what we want to do? https://docs.dimo.org/governance/amendments/dip2a4
+		Level:       v.Level, // 0 in code corresponds to Level 2 in the DIP, and so on. Unfortunate. https://docs.dimo.org/governance/improvement-proposals/dip2
 		Points:      v.Points,
 		Amount:      weiToToken(v.Amount),
 		StakedAt:    v.StakedAt,


### PR DESCRIPTION
Levels are now always 0, 1, 2 in code.