### PR TITLE
Read Definition MMY from definitions

### DIFF
--- a/graph/schema.resolvers_test.go
+++ b/graph/schema.resolvers_test.go
@@ -25,7 +25,7 @@ func TestQueryResolver_Node(t *testing.T) {
 	baseRepo := &base.Repository{}
 
 	vehicleRepo := vehicle.New(baseRepo)
-	testVehicle, err := vehicleRepo.ToAPI(&models.Vehicle{ID: 1}, "", "")
+	testVehicle, err := vehicleRepo.ToAPI(&models.Vehicle{ID: 1}, "", "", nil)
 	require.NoError(t, err)
 
 	aftermarketRepo := aftermarket.New(baseRepo)

--- a/internal/repositories/vehicle/vehicles.go
+++ b/internal/repositories/vehicle/vehicles.go
@@ -78,7 +78,7 @@ func (r *Repository) createVehiclesResponse(totalCount int64, vehicles models.Ve
 			errList = append(errList, gqlerror.Wrap(wErr))
 			continue
 		}
-		gv, err := r.ToAPI(dv, imageURI, dataURI)
+		gv, err := r.ToAPI(dv, imageURI, dataURI, nil)
 		if err != nil {
 			wErr := fmt.Errorf("error converting vehicle to API: %w", err)
 			errList = append(errList, gqlerror.Wrap(wErr))
@@ -244,7 +244,7 @@ func (r *Repository) GetVehicle(ctx context.Context, tokenID *int, tokenDID *str
 		return nil, fmt.Errorf("error getting vehicle data uri: %w", err)
 	}
 
-	return r.ToAPI(v, imageURI, dataURI)
+	return r.ToAPI(v, imageURI, dataURI, nil)
 }
 
 // queryModsFromFilters returns a slice of query mods from the given filters.
@@ -309,7 +309,7 @@ func (r *Repository) queryModsFromFilters(filter *gmodel.VehiclesFilter) ([]qm.Q
 }
 
 // ToAPI converts a vehicle to a corresponding graphql model.
-func (r *Repository) ToAPI(v *models.Vehicle, imageURI string, dataURI string) (*gmodel.Vehicle, error) {
+func (r *Repository) ToAPI(v *models.Vehicle, imageURI string, dataURI string, definition *gmodel.DeviceDefinition) (*gmodel.Vehicle, error) {
 	nameList := mnemonic.FromInt32WithObfuscation(int32(v.ID))
 	name := strings.Join(nameList, " ")
 
@@ -341,6 +341,11 @@ func (r *Repository) ToAPI(v *models.Vehicle, imageURI string, dataURI string) (
 		ImageURI:       imageURI,
 		Image:          imageURI,
 		DataURI:        dataURI,
+	}
+	if definition != nil {
+		out.Definition.Make = &definition.Manufacturer.Name
+		out.Definition.Model = &definition.Model
+		out.Definition.Year = &definition.Year
 	}
 
 	if v.StorageNodeID.Valid {

--- a/internal/repositories/vehicle/vehicles_test.go
+++ b/internal/repositories/vehicle/vehicles_test.go
@@ -1145,7 +1145,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehiclesFilters() {
 	o.Require().NoError(err)
 	vehicle1DataURI, err := GetVehicleDataURI(o.settings.BaseVehicleDataURI, testVehicle1.ID)
 	o.Require().NoError(err)
-	vehicle1AsAPI, err := o.repo.ToAPI(&testVehicle1, vehicle1ImageURL, vehicle1DataURI)
+	vehicle1AsAPI, err := o.repo.ToAPI(&testVehicle1, vehicle1ImageURL, vehicle1DataURI, nil)
 	o.NoError(err)
 
 	testVehicle2 := models.Vehicle{
@@ -1162,7 +1162,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehiclesFilters() {
 	o.Require().NoError(err)
 	vehicle2DataURI, err := GetVehicleDataURI(o.settings.BaseVehicleDataURI, testVehicle2.ID)
 	o.Require().NoError(err)
-	vehicle2AsAPI, err := o.repo.ToAPI(&testVehicle2, vehicle2ImageURL, vehicle2DataURI)
+	vehicle2AsAPI, err := o.repo.ToAPI(&testVehicle2, vehicle2ImageURL, vehicle2DataURI, nil)
 	o.NoError(err)
 
 	testVehicle3 := models.Vehicle{
@@ -1179,7 +1179,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehiclesFilters() {
 	o.Require().NoError(err)
 	vehicle3DataURI, err := GetVehicleDataURI(o.settings.BaseVehicleDataURI, testVehicle3.ID)
 	o.Require().NoError(err)
-	vehicle3AsAPI, err := o.repo.ToAPI(&testVehicle3, vehicle3ImageURL, vehicle3DataURI)
+	vehicle3AsAPI, err := o.repo.ToAPI(&testVehicle3, vehicle3ImageURL, vehicle3DataURI, nil)
 	o.NoError(err)
 
 	testVehicle4 := models.Vehicle{
@@ -1196,7 +1196,7 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehiclesFilters() {
 	o.Require().NoError(err)
 	vehicle4DataURI, err := GetVehicleDataURI(o.settings.BaseVehicleDataURI, testVehicle4.ID)
 	o.Require().NoError(err)
-	vehicle4AsAPI, err := o.repo.ToAPI(&testVehicle4, vehicle4ImageURL, vehicle4DataURI)
+	vehicle4AsAPI, err := o.repo.ToAPI(&testVehicle4, vehicle4ImageURL, vehicle4DataURI, nil)
 	o.Require().NoError(err)
 
 	vehicles := []models.Vehicle{testVehicle1, testVehicle2, testVehicle3, testVehicle4}


### PR DESCRIPTION
This is currently incomplete, but wanted to validate the initial approach first before doing more work on it -  updating the tests, linter and changing all usages of .ToAPI

Background:
The definition ID is what drives what definition the vehicle is set to. Most clients will use the Make, Model, Year in the vehicle response from identity-api to show users their MMY. In the past, we had thought having the MMY on the vehicle nft made sense, but lately seems to add complexity/issues. 
The objective of this PR is to solve for the user experience issues we've seen reported recently, although their may be a bigger underlying issue of changes not getting picked up correctly. 