### PR TITLE
fix: wrap MCP handler with loader.Middleware

### DIFF
--- a/cmd/identity-api/main.go
+++ b/cmd/identity-api/main.go
@@ -91,9 +91,12 @@ func main() {
 		mcpHandler.ServeHTTP(w, r.WithContext(logger.WithContext(r.Context())))
 	})
 
+	// Dataloaders are attached per-request; MCP resolvers need them just like GraphQL.
+	mcpWithLoaders := loader.Middleware(dbs, mcpWithLogger, settings, &repoLogger)
+
 	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
 	http.Handle("/query", srv)
-	http.Handle("/mcp", mcpWithLogger)
+	http.Handle("/mcp", mcpWithLoaders)
 
 	logger.Info().Msgf("Server started on port: %d", settings.Port)
 


### PR DESCRIPTION
## Summary
- Fixes panic \`interface conversion: interface {} is nil, not *loader.Loaders\` on every MCP tool call that resolves \`vehicle.aftermarketDevice\`, \`vehicle.syntheticDevice\`, etc.
- Root cause: MCP resolvers reuse the gqlgen resolvers, which expect \`*loader.Loaders\` in the request context. The \`/query\` path wraps the handler in \`loader.Middleware\`; the \`/mcp\` path did not — so dataloader-backed fields crashed.
- Fix: wrap \`mcpWithLogger\` in \`loader.Middleware\` so each MCP request gets a fresh dataloader set, matching \`/query\` behavior.

## Test plan
- [x] \`go build ./...\` green
- [ ] Deploy to prod, call \`identity_get_vehicle\` with \`tokenId\`: no panic, \`aftermarketDevice\` / \`syntheticDevice\` resolved.