### PR TITLE
feat: handle SACD PermissionsRenounced event

### DIFF
--- a/internal/services/contract_events_consumer_test.go
+++ b/internal/services/contract_events_consumer_test.go
@@ -1954,3 +1954,141 @@ func TestHandlePermissionsSetEventWithTemplate(t *testing.T) {
 	assert.Equal(t, template.ID, relatedTemplate.ID)
 	assert.Equal(t, template.Cid, relatedTemplate.Cid)
 }
+
+func TestHandlePermissionsRenouncedEventVehicle(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.New(os.Stdout).With().Timestamp().Str("app", helpers.DBSettings.Name).Logger()
+
+	contractEventData.EventName = "PermissionsRenounced"
+	contractEventData.Contract = common.HexToAddress(sacdAddr)
+
+	grantee := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	tokenID := big.NewInt(200)
+
+	settings := config.Settings{
+		VehicleNFTAddr:      vehicleIdAddr,
+		SACDAddress:         sacdAddr,
+		DIMORegistryAddr:    dimoRegistryAddr,
+		DIMORegistryChainID: contractEventData.ChainID,
+	}
+
+	pdb, _ := helpers.StartContainerDatabase(ctx, t, migrationsDirRelPath)
+
+	manufacturer := models.Manufacturer{
+		ID:       131,
+		Name:     "Toyota",
+		Owner:    grantee.Bytes(),
+		MintedAt: time.Now(),
+		Slug:     "toyota",
+	}
+	require.NoError(t, manufacturer.Insert(ctx, pdb.DBS().Writer, boil.Infer()))
+
+	vehicle := models.Vehicle{
+		ID:             int(tokenID.Int64()),
+		OwnerAddress:   grantee.Bytes(),
+		MintedAt:       time.Now(),
+		ManufacturerID: 131,
+	}
+	require.NoError(t, vehicle.Insert(ctx, pdb.DBS().Writer, boil.Infer()))
+
+	existing := models.VehicleSacd{
+		VehicleID:   int(tokenID.Int64()),
+		Grantee:     grantee.Bytes(),
+		Permissions: big.NewInt(3888).Text(2),
+		Source:      "test-source",
+		CreatedAt:   time.Now(),
+		ExpiresAt:   time.Now().Add(24 * time.Hour),
+	}
+	require.NoError(t, existing.Insert(ctx, pdb.DBS().Writer, boil.Infer()))
+
+	renounceData := PermissionsRenouncedData{
+		Asset:   common.HexToAddress(vehicleIdAddr),
+		TokenId: tokenID,
+		Grantee: grantee,
+	}
+
+	consumer := NewContractsEventsConsumer(pdb, &logger, &settings)
+	e := prepareEvent(t, contractEventData, renounceData)
+	require.NoError(t, consumer.Process(ctx, &e))
+
+	count, err := models.VehicleSacds(
+		models.VehicleSacdWhere.VehicleID.EQ(int(tokenID.Int64())),
+		models.VehicleSacdWhere.Grantee.EQ(grantee.Bytes()),
+	).Count(ctx, pdb.DBS().Reader)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestHandlePermissionsRenouncedEventAccount(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.New(os.Stdout).With().Timestamp().Str("app", helpers.DBSettings.Name).Logger()
+
+	contractEventData.EventName = "PermissionsRenounced"
+	contractEventData.Contract = common.HexToAddress(sacdAddr)
+
+	account := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	grantee := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	settings := config.Settings{
+		VehicleNFTAddr:      vehicleIdAddr,
+		SACDAddress:         sacdAddr,
+		DIMORegistryAddr:    dimoRegistryAddr,
+		DIMORegistryChainID: contractEventData.ChainID,
+	}
+
+	pdb, _ := helpers.StartContainerDatabase(ctx, t, migrationsDirRelPath)
+
+	existing := models.AccountSacd{
+		Account:     account.Bytes(),
+		Grantee:     grantee.Bytes(),
+		Permissions: big.NewInt(3888).Text(2),
+		Source:      "test-source",
+		CreatedAt:   time.Now(),
+		ExpiresAt:   time.Now().Add(24 * time.Hour),
+	}
+	require.NoError(t, existing.Insert(ctx, pdb.DBS().Writer, boil.Infer()))
+
+	renounceData := PermissionsRenouncedData{
+		Asset:   account,
+		TokenId: big.NewInt(0),
+		Grantee: grantee,
+	}
+
+	consumer := NewContractsEventsConsumer(pdb, &logger, &settings)
+	e := prepareEvent(t, contractEventData, renounceData)
+	require.NoError(t, consumer.Process(ctx, &e))
+
+	count, err := models.AccountSacds(
+		models.AccountSacdWhere.Account.EQ(account.Bytes()),
+		models.AccountSacdWhere.Grantee.EQ(grantee.Bytes()),
+	).Count(ctx, pdb.DBS().Reader)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestHandlePermissionsRenouncedEventNoExistingGrantIsNoop(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.New(os.Stdout).With().Timestamp().Str("app", helpers.DBSettings.Name).Logger()
+
+	contractEventData.EventName = "PermissionsRenounced"
+	contractEventData.Contract = common.HexToAddress(sacdAddr)
+
+	settings := config.Settings{
+		VehicleNFTAddr:      vehicleIdAddr,
+		SACDAddress:         sacdAddr,
+		DIMORegistryAddr:    dimoRegistryAddr,
+		DIMORegistryChainID: contractEventData.ChainID,
+	}
+
+	pdb, _ := helpers.StartContainerDatabase(ctx, t, migrationsDirRelPath)
+
+	renounceData := PermissionsRenouncedData{
+		Asset:   common.HexToAddress(vehicleIdAddr),
+		TokenId: big.NewInt(999),
+		Grantee: common.HexToAddress("0x1234567890123456789012345678901234567890"),
+	}
+
+	consumer := NewContractsEventsConsumer(pdb, &logger, &settings)
+	e := prepareEvent(t, contractEventData, renounceData)
+	require.NoError(t, consumer.Process(ctx, &e))
+}

--- a/internal/services/contracts_events_consumer.go
+++ b/internal/services/contracts_events_consumer.go
@@ -48,7 +48,8 @@ const (
 	BeneficiarySetEvent EventName = "BeneficiarySet"
 
 	// SACD.
-	PermissionsSetEvent EventName = "PermissionsSet"
+	PermissionsSetEvent       EventName = "PermissionsSet"
+	PermissionsRenouncedEvent EventName = "PermissionsRenounced"
 
 	// Template.
 	TemplateCreatedEvent EventName = "TemplateCreated"
@@ -206,6 +207,8 @@ func (c *ContractsEventsConsumer) Process(ctx context.Context, event *cloudevent
 		switch eventName {
 		case PermissionsSetEvent:
 			return c.handlePermissionsSetEvent(ctx, &data)
+		case PermissionsRenouncedEvent:
+			return c.handlePermissionsRenouncedEvent(ctx, &data)
 		}
 	case templateAddr:
 		switch eventName {
@@ -688,6 +691,54 @@ func (c *ContractsEventsConsumer) handlePermissionsSetEvent(ctx context.Context,
 		Int64("vehicleId", args.TokenId.Int64()).
 		Str("grantee", args.Grantee.Hex()).
 		Msg("Vehicle SACD processed.")
+
+	return nil
+}
+
+func (c *ContractsEventsConsumer) handlePermissionsRenouncedEvent(ctx context.Context, e *cmodels.ContractEventData) error {
+	logger := c.log.With().Str("EventName", PermissionsRenouncedEvent.String()).Logger()
+
+	var args PermissionsRenouncedData
+	if err := json.Unmarshal(e.Arguments, &args); err != nil {
+		return fmt.Errorf("error unmarshaling PermissionsRenounced inputs: %w", err)
+	}
+
+	if args.TokenId.Sign() == 0 {
+		n, err := models.AccountSacds(
+			models.AccountSacdWhere.Account.EQ(args.Asset.Bytes()),
+			models.AccountSacdWhere.Grantee.EQ(args.Grantee.Bytes()),
+		).DeleteAll(ctx, c.dbs.DBS().Writer)
+		if err != nil {
+			return fmt.Errorf("error deleting account SACD: %w", err)
+		}
+
+		logger.Info().
+			Str("account", args.Asset.Hex()).
+			Str("grantee", args.Grantee.Hex()).
+			Int64("deleted", n).
+			Msg("Account SACD renounced.")
+
+		return nil
+	}
+
+	if args.Asset != common.HexToAddress(c.settings.VehicleNFTAddr) {
+		logger.Warn().Msgf("SACD renounced for non-vehicle asset %s.", args.Asset.Hex())
+		return nil
+	}
+
+	n, err := models.VehicleSacds(
+		models.VehicleSacdWhere.VehicleID.EQ(int(args.TokenId.Int64())),
+		models.VehicleSacdWhere.Grantee.EQ(args.Grantee.Bytes()),
+	).DeleteAll(ctx, c.dbs.DBS().Writer)
+	if err != nil {
+		return fmt.Errorf("error deleting vehicle SACD: %w", err)
+	}
+
+	logger.Info().
+		Int64("vehicleId", args.TokenId.Int64()).
+		Str("grantee", args.Grantee.Hex()).
+		Int64("deleted", n).
+		Msg("Vehicle SACD renounced.")
 
 	return nil
 }

--- a/internal/services/event_data_models.go
+++ b/internal/services/event_data_models.go
@@ -166,6 +166,12 @@ type PermissionsSetData struct {
 	Source      string
 }
 
+type PermissionsRenouncedData struct {
+	Asset   common.Address
+	TokenId *big.Int
+	Grantee common.Address
+}
+
 type PermissionsSetWithTemplateData struct {
 	Asset       common.Address
 	TokenId     *big.Int


### PR DESCRIPTION
## Summary
- Adds support for the new SACD `PermissionsRenounced(asset, tokenId, grantee)` event (grantee-side revocation).
- Deletes the matching `account_sacds` row when `tokenId == 0`, otherwise the `vehicle_sacds` row keyed by `(vehicle_id, grantee)`. Reuses the `asset == VehicleNFTAddr` guard that `PermissionsSet` already applies to non-vehicle assets.
- No migration: both SACD tables already key on `(asset, grantee)`, so this is a single targeted delete. Per product framing, we do not retain a revocation timestamp — the agreement just stops showing.

## Test plan
- [x] `go test ./internal/services/ -run 'TestHandlePermissions(Set|Renounced)'` passes locally
- [ ] Vehicle renounce: existing `vehicle_sacds` row is deleted
- [ ] Account renounce (`tokenId == 0`): existing `account_sacds` row is deleted
- [ ] Renounce with no prior grant is a no-op (no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)