### PR TITLE
feat(manufacturer): index imageURI + devLicenseClientId attributes

### DIFF
--- a/graph/schema/manufacturer.graphqls
+++ b/graph/schema/manufacturer.graphqls
@@ -49,6 +49,18 @@ type Manufacturer implements Node {
   """
   mintedAt: Time!
   """
+  URI pointing to the manufacturer's logo image. Typically an `ipfs://Qm…`
+  link served via the DIMO gateway. May also be `https://…`.
+  """
+  imageURI: String
+  """
+  The clientId (Ethereum address) of the developer license authoritatively
+  associated with this manufacturer. Set on-chain via the manufacturer's
+  `devLicenseClientId` attribute. Lets SDKs resolve "which OEM is this dev
+  license?" in one query.
+  """
+  devLicenseClientId: Address
+  """
   A Relay-style connection listing any aftermarket devices associated with manufacturer.
   """
   aftermarketDevices(
@@ -96,6 +108,12 @@ input ManufacturerBy @oneOf {
   The DID of the manufacturer in the format did:erc721:<chainID>:<contractAddress>:<tokenId>
   """
   tokenDID: String @goField(name: "TokenDID")
+  """
+  Look up a manufacturer by the clientId Address of its associated developer
+  license. Useful for SDKs that have a clientId in hand and need to discover
+  the OEM (name + logo) without a separate registry.
+  """
+  devLicenseClientId: Address
 }
 
 """

--- a/internal/repositories/manufacturer/manufacturer.go
+++ b/internal/repositories/manufacturer/manufacturer.go
@@ -51,14 +51,22 @@ func (r *Repository) ToAPI(m *models.Manufacturer) (*gmodel.Manufacturer, error)
 		TokenID:         new(big.Int).SetUint64(uint64(m.ID)),
 	}.String()
 
+	var devLicenseClientID *common.Address
+	if len(m.DevLicenseClientID) != 0 {
+		a := common.BytesToAddress(m.DevLicenseClientID)
+		devLicenseClientID = &a
+	}
+
 	return &gmodel.Manufacturer{
-		ID:       globalID,
-		TokenID:  m.ID,
-		TokenDID: tokenDID,
-		Owner:    common.BytesToAddress(m.Owner),
-		TableID:  m.TableID.Ptr(),
-		MintedAt: m.MintedAt,
-		Name:     m.Name,
+		ID:                 globalID,
+		TokenID:            m.ID,
+		TokenDID:           tokenDID,
+		Owner:              common.BytesToAddress(m.Owner),
+		TableID:            m.TableID.Ptr(),
+		MintedAt:           m.MintedAt,
+		Name:               m.Name,
+		ImageURI:           m.ImageURI.Ptr(),
+		DevLicenseClientID: devLicenseClientID,
 	}, nil
 }
 
@@ -74,8 +82,8 @@ func IDToToken(b []byte) (int, error) {
 }
 
 func (r *Repository) GetManufacturer(ctx context.Context, by gmodel.ManufacturerBy) (*gmodel.Manufacturer, error) {
-	if base.CountTrue(by.TokenID != nil, by.Name != nil, by.Slug != nil, by.TokenDID != nil) != 1 {
-		return nil, gqlerror.Errorf("Provide exactly one of `name`, `tokenID`, `slug`, or `tokenDID`.")
+	if base.CountTrue(by.TokenID != nil, by.Name != nil, by.Slug != nil, by.TokenDID != nil, by.DevLicenseClientID != nil) != 1 {
+		return nil, gqlerror.Errorf("Provide exactly one of `name`, `tokenID`, `slug`, `tokenDID`, or `devLicenseClientId`.")
 	}
 
 	var qm qm.QueryMod
@@ -86,6 +94,8 @@ func (r *Repository) GetManufacturer(ctx context.Context, by gmodel.Manufacturer
 		qm = models.ManufacturerWhere.Name.EQ(*by.Name)
 	case by.Slug != nil:
 		qm = models.ManufacturerWhere.Slug.EQ(*by.Slug)
+	case by.DevLicenseClientID != nil:
+		qm = models.ManufacturerWhere.DevLicenseClientID.EQ(by.DevLicenseClientID.Bytes())
 	case by.TokenDID != nil:
 		did, err := cloudevent.DecodeERC721DID(*by.TokenDID)
 		if err != nil {

--- a/internal/services/contract_events_consumer_test.go
+++ b/internal/services/contract_events_consumer_test.go
@@ -137,6 +137,125 @@ func TestHandleAftermarketDeviceAttributeSetEvent(t *testing.T) {
 	assert.Equal(t, time.Time{}, ad.MintedAt)
 }
 
+func TestHandleManufacturerAttributeSetEvent(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.New(os.Stdout).With().Timestamp().Str("app", helpers.DBSettings.Name).Logger()
+	settings := config.Settings{
+		DIMORegistryAddr:    contractEventData.Contract.String(),
+		DIMORegistryChainID: contractEventData.ChainID,
+	}
+
+	const tokenID = 131
+	devLicense := common.HexToAddress("0xb92d74B468B4047289AEa7c9B953066E39768C16")
+	imageURI := "ipfs://QmaYY8pNKDNbo8yHha9z3k3FU5ejwJyBJDbPBWSUwJYkue"
+
+	t.Run("sets imageURI", func(t *testing.T) {
+		contractEventData.EventName = string(ManufacturerAttributeSet)
+
+		pdb, _ := helpers.StartContainerDatabase(ctx, t, migrationsDirRelPath)
+		consumer := NewContractsEventsConsumer(pdb, &logger, &settings)
+
+		mfr := models.Manufacturer{
+			ID:    tokenID,
+			Name:  "Toyota",
+			Owner: common.FromHex("0xCED3c922200559128930180d3f0bfFd4d9f4F123"),
+			Slug:  "toyota",
+		}
+		require.NoError(t, mfr.Insert(ctx, pdb.DBS().Writer, boil.Infer()))
+
+		e := prepareEvent(t, contractEventData, ManufacturerAttributeSetData{
+			TokenID:   big.NewInt(tokenID),
+			Attribute: "imageURI",
+			Info:      imageURI,
+		})
+		require.NoError(t, consumer.Process(ctx, &e))
+
+		got, err := models.FindManufacturer(ctx, pdb.DBS().Reader, tokenID)
+		require.NoError(t, err)
+		assert.Equal(t, imageURI, got.ImageURI.String)
+		assert.True(t, got.ImageURI.Valid)
+	})
+
+	t.Run("sets devLicenseClientId", func(t *testing.T) {
+		contractEventData.EventName = string(ManufacturerAttributeSet)
+
+		pdb, _ := helpers.StartContainerDatabase(ctx, t, migrationsDirRelPath)
+		consumer := NewContractsEventsConsumer(pdb, &logger, &settings)
+
+		mfr := models.Manufacturer{
+			ID:    tokenID,
+			Name:  "Toyota",
+			Owner: common.FromHex("0xCED3c922200559128930180d3f0bfFd4d9f4F123"),
+			Slug:  "toyota",
+		}
+		require.NoError(t, mfr.Insert(ctx, pdb.DBS().Writer, boil.Infer()))
+
+		e := prepareEvent(t, contractEventData, ManufacturerAttributeSetData{
+			TokenID:   big.NewInt(tokenID),
+			Attribute: "devLicenseClientId",
+			Info:      devLicense.Hex(),
+		})
+		require.NoError(t, consumer.Process(ctx, &e))
+
+		got, err := models.FindManufacturer(ctx, pdb.DBS().Reader, tokenID)
+		require.NoError(t, err)
+		assert.Equal(t, devLicense.Bytes(), got.DevLicenseClientID)
+	})
+
+	t.Run("rejects malformed imageURI", func(t *testing.T) {
+		contractEventData.EventName = string(ManufacturerAttributeSet)
+
+		pdb, _ := helpers.StartContainerDatabase(ctx, t, migrationsDirRelPath)
+		consumer := NewContractsEventsConsumer(pdb, &logger, &settings)
+
+		mfr := models.Manufacturer{ID: tokenID, Name: "Toyota", Owner: common.FromHex("0x00"), Slug: "toyota"}
+		require.NoError(t, mfr.Insert(ctx, pdb.DBS().Writer, boil.Infer()))
+
+		e := prepareEvent(t, contractEventData, ManufacturerAttributeSetData{
+			TokenID:   big.NewInt(tokenID),
+			Attribute: "imageURI",
+			Info:      "not a uri",
+		})
+		err := consumer.Process(ctx, &e)
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects malformed devLicenseClientId", func(t *testing.T) {
+		contractEventData.EventName = string(ManufacturerAttributeSet)
+
+		pdb, _ := helpers.StartContainerDatabase(ctx, t, migrationsDirRelPath)
+		consumer := NewContractsEventsConsumer(pdb, &logger, &settings)
+
+		mfr := models.Manufacturer{ID: tokenID, Name: "Toyota", Owner: common.FromHex("0x00"), Slug: "toyota"}
+		require.NoError(t, mfr.Insert(ctx, pdb.DBS().Writer, boil.Infer()))
+
+		e := prepareEvent(t, contractEventData, ManufacturerAttributeSetData{
+			TokenID:   big.NewInt(tokenID),
+			Attribute: "devLicenseClientId",
+			Info:      "deadbeef",
+		})
+		err := consumer.Process(ctx, &e)
+		assert.Error(t, err)
+	})
+
+	t.Run("ignores unknown attribute", func(t *testing.T) {
+		contractEventData.EventName = string(ManufacturerAttributeSet)
+
+		pdb, _ := helpers.StartContainerDatabase(ctx, t, migrationsDirRelPath)
+		consumer := NewContractsEventsConsumer(pdb, &logger, &settings)
+
+		mfr := models.Manufacturer{ID: tokenID, Name: "Toyota", Owner: common.FromHex("0x00"), Slug: "toyota"}
+		require.NoError(t, mfr.Insert(ctx, pdb.DBS().Writer, boil.Infer()))
+
+		e := prepareEvent(t, contractEventData, ManufacturerAttributeSetData{
+			TokenID:   big.NewInt(tokenID),
+			Attribute: "newFutureAttribute",
+			Info:      "whatever",
+		})
+		assert.NoError(t, consumer.Process(ctx, &e))
+	})
+}
+
 func TestHandleAftermarketDevicePairedEvent(t *testing.T) {
 	ctx := context.Background()
 	logger := zerolog.New(os.Stdout).With().Timestamp().Str("app", helpers.DBSettings.Name).Logger()

--- a/internal/services/contracts_events_consumer.go
+++ b/internal/services/contracts_events_consumer.go
@@ -55,6 +55,7 @@ const (
 
 	// Manufacturers.
 	ManufacturerNodeMinted       EventName = "ManufacturerNodeMinted"
+	ManufacturerAttributeSet     EventName = "ManufacturerAttributeSet"
 	DeviceDefinitionTableCreated EventName = "DeviceDefinitionTableCreated"
 	ManufacturerTableSet         EventName = "ManufacturerTableSet"
 
@@ -157,6 +158,8 @@ func (c *ContractsEventsConsumer) Process(ctx context.Context, event *cloudevent
 		switch eventName {
 		case ManufacturerNodeMinted:
 			return c.handleManufacturerNodeMintedEvent(ctx, &data)
+		case ManufacturerAttributeSet:
+			return c.handleManufacturerAttributeSetEvent(ctx, &data)
 		case DeviceDefinitionTableCreated:
 			return c.handleDeviceDefinitionTableCreated(ctx, &data)
 		case ManufacturerTableSet:
@@ -302,6 +305,57 @@ func (c *ContractsEventsConsumer) handleDeviceDefinitionTableCreated(ctx context
 
 	_, err := mfr.Update(ctx, c.dbs.DBS().Writer, boil.Whitelist(models.ManufacturerColumns.TableID))
 	return err
+}
+
+// handleManufacturerAttributeSetEvent persists per-Manufacturer brand metadata
+// written on-chain via setManufacturerInfo. Two attributes are recognised today:
+//
+//   - "imageURI"           — URI for the OEM's logo (e.g. ipfs://Qm…).
+//   - "devLicenseClientId" — the dev license client id (an Ethereum address)
+//                            this manufacturer authoritatively maps to. Used
+//                            by SDKs to look up "which OEM is this dev
+//                            license?" without a separate registry.
+//
+// Unknown attributes are logged and ignored so future on-chain attribute
+// additions don't crash the consumer.
+func (c *ContractsEventsConsumer) handleManufacturerAttributeSetEvent(ctx context.Context, e *cmodels.ContractEventData) error {
+	var args ManufacturerAttributeSetData
+	if err := json.Unmarshal(e.Arguments, &args); err != nil {
+		return err
+	}
+
+	mfr := models.Manufacturer{ID: int(args.TokenID.Int64())}
+
+	switch args.Attribute {
+	case "imageURI":
+		var imageURI null.String
+		if args.Info != "" {
+			if _, err := url.ParseRequestURI(args.Info); err != nil {
+				return fmt.Errorf("invalid manufacturer imageURI %q: %w", args.Info, err)
+			}
+			imageURI = null.StringFrom(args.Info)
+		}
+		mfr.ImageURI = imageURI
+		_, err := mfr.Update(ctx, c.dbs.DBS().Writer, boil.Whitelist(models.ManufacturerColumns.ImageURI))
+		return err
+	case "devLicenseClientId":
+		var clientID []byte
+		if args.Info != "" {
+			if !common.IsHexAddress(args.Info) {
+				return fmt.Errorf("invalid manufacturer devLicenseClientId %q: not a 0x-prefixed 40-hex address", args.Info)
+			}
+			clientID = common.HexToAddress(args.Info).Bytes()
+		}
+		mfr.DevLicenseClientID = clientID
+		_, err := mfr.Update(ctx, c.dbs.DBS().Writer, boil.Whitelist(models.ManufacturerColumns.DevLicenseClientID))
+		return err
+	default:
+		c.log.Warn().
+			Str("attribute", args.Attribute).
+			Int64("tokenId", args.TokenID.Int64()).
+			Msg("Unrecognised manufacturer attribute; ignoring.")
+		return nil
+	}
 }
 
 func (c *ContractsEventsConsumer) handleManufacturerTableSet(ctx context.Context, e *cmodels.ContractEventData) error {

--- a/internal/services/event_data_models.go
+++ b/internal/services/event_data_models.go
@@ -38,6 +38,12 @@ type ManufacturerNodeMintedData struct {
 	Owner   common.Address
 }
 
+type ManufacturerAttributeSetData struct {
+	TokenID   *big.Int
+	Attribute string
+	Info      string
+}
+
 type AftermarketDeviceAttributeSetData struct {
 	TokenID   *big.Int
 	Attribute string

--- a/migrations/00049_manufacturer_image_uri_dev_license_client_id.sql
+++ b/migrations/00049_manufacturer_image_uri_dev_license_client_id.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE manufacturers
+    ADD COLUMN image_uri              TEXT,
+    ADD COLUMN dev_license_client_id  BYTEA
+        CONSTRAINT manufacturers_dev_license_client_id_check
+        CHECK (dev_license_client_id IS NULL OR length(dev_license_client_id) = 20);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE manufacturers
+    DROP COLUMN dev_license_client_id,
+    DROP COLUMN image_uri;
+-- +goose StatementEnd


### PR DESCRIPTION
## Summary

Adds support for two new on-chain `Manufacturer` attributes:

| Attribute | Type | Example |
|---|---|---|
| `imageURI` | `TEXT` | `ipfs://QmaYY8pNKDNbo8yHha9z3k3FU5ejwJyBJDbPBWSUwJYkue` |
| `devLicenseClientId` | `Address` | `0xb92d74B468B4047289AEa7c9B953066E39768C16` |

Together they let SDKs answer **"which OEM is this dev license, and what's its logo?"** in one GraphQL round-trip:

```graphql
query {
  manufacturer(by: { devLicenseClientId: "0xb92d74…" }) {
    name      # "Toyota"
    imageURI  # "ipfs://Qm…"
  }
}
```

This is the indexing half of the platform pattern that lets the auth popup, the SDK button, and any consumer-side rendering brand themselves automatically from the dev license alone — no per-tenant config needed.

## Architecture

- Contract side: **no Solidity change.** `Manufacturer.sol` already supports whitelisted string attributes via `setManufacturerInfo(tokenId, AttributeInfoPair[])` which emits `ManufacturerAttributeSet`. Pattern mirrors `Vehicle.imageURI`.
- This PR teaches identity-api to **consume** that event and surface the two attributes on the existing `Manufacturer` type.

## Changes

- **`migrations/00049_manufacturer_image_uri_dev_license_client_id.sql`** — adds `image_uri TEXT` + `dev_license_client_id BYTEA(20)` to `manufacturers`. Down-migration is the reverse drop.
- **`internal/services/event_data_models.go`** — `ManufacturerAttributeSetData` struct (3-field shape matching the existing Vehicle / AftermarketDevice variants).
- **`internal/services/contracts_events_consumer.go`**
  - New `ManufacturerAttributeSet` event name in the Manufacturers const block.
  - New switch case under `registryAddr`.
  - New `handleManufacturerAttributeSetEvent` mirroring `handleVehicleAttributeSetEvent`:
    - `imageURI` URL-validates via `url.ParseRequestURI` (accepts `ipfs://`, `https://`)
    - `devLicenseClientId` validates via `common.IsHexAddress`, stores 20 bytes
    - Unknown attributes are logged and ignored (forward-compatible with future on-chain additions)
    - Both branches are idempotent — repeated events overwrite, never fail
- **`graph/schema/manufacturer.graphqls`** — adds nullable `imageURI: String`, `devLicenseClientId: Address` to `Manufacturer`; adds `devLicenseClientId: Address` branch to `ManufacturerBy @oneOf`.
- **`internal/repositories/manufacturer/manufacturer.go`** — `ToAPI` threads the two new fields through; `GetManufacturer` gains the `DevLicenseClientID` filter and an updated `CountTrue` arity guard.
- **`internal/services/contract_events_consumer_test.go`** — `TestHandleManufacturerAttributeSetEvent` covers both happy paths, both validation failures, and unknown-attribute pass-through.

## Reviewer steps

After checkout, regenerate the autogen artefacts:

```bash
make migrate     # applies 00049
make sqlboiler   # regenerates models/manufacturers.go
make gql         # regenerates graph/model/models_gen.go + graph/generated.go
```

Then `go test ./internal/services/...` should pass (test runs against a containerised pg).

## Backfill

Any `ManufacturerAttributeSet` events emitted before this consumer ships will **not** auto-replay — the Kafka consumer group keeps committed offsets and there is no `AutoOffsetReset: earliest` override. For v1 we plan to write the attributes via Safe multisig **after** this PR is deployed, so backfill isn't blocking. If we end up needing one later, the cleanest path is a one-off `cmd/backfill-manufacturer-attributes/main.go` that loops over `models.Manufacturers()` and calls `Registry.getInfo(tokenId, "imageURI")` / `getInfo(tokenId, "devLicenseClientId")` via `eth_call` then upserts the columns directly. Tracking issue: TBD.

## Out of scope

- Solidity changes (none needed)
- Attribute whitelisting + per-OEM `setManufacturerInfo` txs (handled separately via Gnosis Safe Transaction Builder; see `toyota-demo/ops/`)
- Logo pinning (handled separately; `toyota-demo/ops/pin-logos.ts` uses `https://assets.dimo.org/ipfs`)
- SDK + auth-popup integration (lights up automatically once this PR ships and the safe-txs execute)