### PR TITLE
feat: filter vehicles by synthetic device connection

### DIFF
--- a/graph/generated.go
+++ b/graph/generated.go
@@ -15266,7 +15266,7 @@ func (ec *executionContext) unmarshalInputVehiclesFilter(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"privileged", "owner", "make", "model", "year", "manufacturerTokenId", "deviceDefinitionId"}
+	fieldsInOrder := [...]string{"privileged", "owner", "make", "model", "year", "manufacturerTokenId", "deviceDefinitionId", "connection"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -15322,6 +15322,13 @@ func (ec *executionContext) unmarshalInputVehiclesFilter(ctx context.Context, ob
 				return it, err
 			}
 			it.DeviceDefinitionID = data
+		case "connection":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("connection"))
+			data, err := ec.unmarshalOAddress2ᚖgithubᚗcomᚋethereumᚋgoᚑethereumᚋcommonᚐAddress(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Connection = data
 		}
 	}
 	return it, nil

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -762,4 +762,7 @@ type VehiclesFilter struct {
 	ManufacturerTokenID *int `json:"manufacturerTokenId,omitempty"`
 	// Filter for vehicles by device definition id.
 	DeviceDefinitionID *string `json:"deviceDefinitionId,omitempty"`
+	// Filter for vehicles paired with a synthetic device that belongs to the connection at
+	// this address.
+	Connection *common.Address `json:"connection,omitempty"`
 }

--- a/graph/schema/vehicle.graphqls
+++ b/graph/schema/vehicle.graphqls
@@ -92,6 +92,12 @@ input VehiclesFilter {
   Filter for vehicles by device definition id.
   """
   deviceDefinitionId: String
+
+  """
+  Filter for vehicles paired with a synthetic device that belongs to the connection at
+  this address.
+  """
+  connection: Address
 }
 
 type Vehicle implements Node {

--- a/internal/repositories/vehicle/vehicles.go
+++ b/internal/repositories/vehicle/vehicles.go
@@ -307,6 +307,21 @@ func (r *Repository) queryModsFromFilters(filter *gmodel.VehiclesFilter) ([]qm.Q
 	if filter.DeviceDefinitionID != nil {
 		queryMods = append(queryMods, models.VehicleWhere.DeviceDefinitionID.EQ(null.StringFrom(*filter.DeviceDefinitionID)))
 	}
+	if filter.Connection != nil {
+		// A vehicle is linked to a connection through its synthetic device, so join
+		// vehicles -> synthetic_devices -> connections and filter on the connection address.
+		queryMods = append(queryMods,
+			qm.InnerJoin(
+				helpers.WithSchema(models.TableNames.SyntheticDevices)+" ON "+
+					models.SyntheticDeviceTableColumns.VehicleID+" = "+models.VehicleTableColumns.ID,
+			),
+			qm.InnerJoin(
+				helpers.WithSchema(models.TableNames.Connections)+" ON "+
+					models.ConnectionTableColumns.ID+" = "+models.SyntheticDeviceTableColumns.ConnectionID,
+			),
+			models.ConnectionWhere.Address.EQ(filter.Connection.Bytes()),
+		)
+	}
 
 	return queryMods, nil
 }

--- a/internal/repositories/vehicle/vehicles_test.go
+++ b/internal/repositories/vehicle/vehicles_test.go
@@ -1223,6 +1223,55 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehiclesFilters() {
 		}
 	}
 
+	// Two connections, each paired with a vehicle through a synthetic device. Vehicles 2 and 4
+	// have no synthetic device, so they never match a connection filter.
+	connectionAddr1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	connectionAddr2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	connections := []models.Connection{
+		{
+			ID:       common.FromHex("0x0000000000000000000000000000000000000000000000000000000000000001"),
+			Address:  connectionAddr1.Bytes(),
+			Owner:    wallet1.Bytes(),
+			MintedAt: currTime,
+		},
+		{
+			ID:       common.FromHex("0x0000000000000000000000000000000000000000000000000000000000000002"),
+			Address:  connectionAddr2.Bytes(),
+			Owner:    wallet1.Bytes(),
+			MintedAt: currTime,
+		},
+	}
+	for _, c := range connections {
+		if err := c.Insert(o.ctx, o.pdb.DBS().Writer, boil.Infer()); err != nil {
+			o.Require().NoError(err)
+		}
+	}
+
+	syntheticDevices := []models.SyntheticDevice{
+		{
+			ID:            1,
+			IntegrationID: 1,
+			VehicleID:     testVehicle1.ID,
+			DeviceAddress: common.HexToAddress("0xaaaa000000000000000000000000000000000001").Bytes(),
+			MintedAt:      currTime,
+			ConnectionID:  null.BytesFrom(connections[0].ID),
+		},
+		{
+			ID:            2,
+			IntegrationID: 1,
+			VehicleID:     testVehicle3.ID,
+			DeviceAddress: common.HexToAddress("0xaaaa000000000000000000000000000000000003").Bytes(),
+			MintedAt:      currTime,
+			ConnectionID:  null.BytesFrom(connections[1].ID),
+		},
+	}
+	for _, sd := range syntheticDevices {
+		if err := sd.Insert(o.ctx, o.pdb.DBS().Writer, boil.Infer()); err != nil {
+			o.Require().NoError(err)
+		}
+	}
+
 	// create table of tests for testing the o.repo.GetVehicles function
 	tests := []struct {
 		name    string
@@ -1389,6 +1438,33 @@ func (o *AccessibleVehiclesRepoTestSuite) Test_GetAccessibleVehiclesFilters() {
 				{Node: vehicle1AsAPI},
 				{Node: vehicle3AsAPI},
 			},
+		},
+		{
+			name: "Filter by Connection",
+			filter: &gmodel.VehiclesFilter{
+				Connection: &connectionAddr1,
+			},
+			results: []*gmodel.VehicleEdge{
+				{Node: vehicle1AsAPI},
+			},
+		},
+		{
+			name: "Filter by Connection and Owner",
+			filter: &gmodel.VehiclesFilter{
+				Connection: &connectionAddr2,
+				Owner:      wallet2,
+			},
+			results: []*gmodel.VehicleEdge{
+				{Node: vehicle3AsAPI},
+			},
+		},
+		{
+			name: "Filter by Connection no results",
+			filter: &gmodel.VehiclesFilter{
+				Connection: &connectionAddr2,
+				Owner:      wallet1,
+			},
+			results: []*gmodel.VehicleEdge{},
 		},
 	}
 


### PR DESCRIPTION
## What

Adds a `connection` field to `VehiclesFilter` so callers can list all vehicles paired with a synthetic device that belongs to a given connection, keyed by the connection's address:

```graphql
{
  vehicles(first: 100, filterBy: { connection: "0x1111...1111" }) {
    totalCount
    nodes { tokenId owner syntheticDevice { tokenId } }
  }
}
```

Because it's a filter on the existing `vehicles` query, it composes with the other filters for free — e.g. `filterBy: { connection: "0x...", make: "Toyota", owner: "0x..." }`.

## How

A vehicle links to a connection only through its synthetic device, and `synthetic_devices.connection_id` is a FK to `connections.id` (the 32-byte padded name), **not** the address. So when the filter is set, `queryModsFromFilters` joins `vehicles → synthetic_devices → connections` and filters on `connections.address`. No migration required.

## Tests

Added connection + synthetic-device fixtures to the vehicle filter suite and three cases: connection alone, connection + owner, and a no-results combo. Full `internal/repositories/vehicle` package suite passes.

## Notes / open questions

- **Naming**: went with the plain `connection` on the filter. `syntheticDeviceConnection` would be more self-documenting but verbose — happy to rename.
- **MCP**: did not add an `@mcpExample` demonstrating the connection filter on the `vehicles` query. Can add one if we want the MCP tool to advertise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)